### PR TITLE
Sanitize all shortcode atts

### DIFF
--- a/gigpress.php
+++ b/gigpress.php
@@ -406,8 +406,6 @@ function gigpress_prepare( $show, $scope = 'public' ) {
 
 function gigpress_sanitize_sort($sort_value, $default = false, $safe_values = array('asc', 'desc')) {
     if (!in_array($sort_value, $safe_values, true)) {
-        // DEBUG
-        debug_log('hui, seems, to have an SQL injection attempt here? "'. $sort_value . '"');
         return $default;
     }
     return $sort_value;

--- a/gigpress.php
+++ b/gigpress.php
@@ -3,7 +3,7 @@
  * Plugin Name: GigPress
  * Plugin URI:  https://evnt.is/1aca
  * Description: GigPress is a live performance listing and management plugin built for musicians and performers.
- * Version:     2.3.28
+ * Version:     2.3.29
  * Author:      The Events Calendar
  * Author URI:  https://evnt.is/1aor
  * Text Domain: gigpress
@@ -46,7 +46,7 @@ if ( ! defined( 'GIGPRESS_VENUES' ) ) {
 }
 
 if ( ! defined( 'GIGPRESS_VERSION' ) ) {
-	define( 'GIGPRESS_VERSION', '2.3.26' );
+	define( 'GIGPRESS_VERSION', '2.3.29' );
 }
 
 if ( ! defined( 'GIGPRESS_DB_VERSION' ) ) {

--- a/gigpress.php
+++ b/gigpress.php
@@ -404,6 +404,16 @@ function gigpress_prepare( $show, $scope = 'public' ) {
 }
 
 
+function gigpress_sanitize_sort($sort_value, $default = false, $safe_values = array('asc', 'desc')) {
+    if (!in_array($sort_value, $safe_values, true)) {
+        // DEBUG
+        debug_log('hui, seems, to have an SQL injection attempt here? "'. $sort_value . '"');
+        return $default;
+    }
+    return $sort_value;
+}
+
+
 function gigpress_related_link( $postid, $format) {
 
 	if ( $postid == 0 ) return;

--- a/output/gigpress_related.php
+++ b/output/gigpress_related.php
@@ -17,6 +17,8 @@ function gigpress_show_related($args = array(), $content = '') {
 			'sort' => 'asc'
 		), $args));
 
+		$sort = gigpress_sanitize_sort($sort, $default = 'asc');
+
 		// Date conditionals based on scope
 		switch($scope) {
 			case 'upcoming':

--- a/output/gigpress_shows.php
+++ b/output/gigpress_shows.php
@@ -44,6 +44,8 @@ function gigpress_shows( $filter = null, $content = null ) {
 		), $filter )
 	);
 
+	$sort = gigpress_sanitize_sort($sort);
+	
 	$total_artists = $wpdb->get_var( "SELECT count(*) from " . GIGPRESS_ARTISTS );
 
 	// Date conditionals and sorting based on scope
@@ -346,6 +348,8 @@ function gigpress_menu( $options = null ) {
 		'venue'      => false,
 		'sort'       => 'desc',
 	), $options ) );
+
+	$sort = gigpress_sanitize_sort($sort, $default='desc');
 
 	$base .= ( strpos( $base, '?' ) === false ) ? '?' : '&amp;';
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: theeventscalendar, brianjessee, camwynsp, aguseo, bordoni, borkweb
 Tags: concerts, bands, tours, shows, record labels, music, musicians, performers, artists
 Requires at least: 4.5
 Tested up to: 6.1.1
-Stable tag: 2.3.28
+Stable tag: 2.3.29
 
 GigPress is a live performance listing and management plugin that's been serving musicians and performers since 2007.
 
@@ -35,6 +35,10 @@ If you want to go beyond GigPress, we also have other plugins that could work gr
 * Check out the full <a href="https://theeventscalendar.com/products/">list of premium plugins</a> we offer.
 
 == Changelog ==
+
+= 2.3.29 [2023-02-25] =
+
+* Tweak - Imporving safety for all shortcoe parameters
 
 = 2.3.28 [2022-12-27] =
 

--- a/readme.txt
+++ b/readme.txt
@@ -38,7 +38,7 @@ If you want to go beyond GigPress, we also have other plugins that could work gr
 
 = 2.3.29 [2023-02-25] =
 
-* Tweak - Imporving safety for all shortcoe parameters
+* Tweak - Improving safety for all shortcode parameters
 
 = 2.3.28 [2022-12-27] =
 


### PR DESCRIPTION
This should fix [the reason](https://wpscan.com/vulnerability/39c964fa-6d8d-404d-ac38-72f6f88d203c) why this plugin currently is blocked in the wp plugin directory.